### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+    - run: npm install
+    - run: npm run prod-build


### PR DESCRIPTION
This adds a Github Actions pipeline that will compile the application for every pull request.

Unfortunately, this cannot be tested locally but must be merged in order to run.